### PR TITLE
make rust beta clippy happy

### DIFF
--- a/benchmark/src/engines/std_thread.rs
+++ b/benchmark/src/engines/std_thread.rs
@@ -107,7 +107,7 @@ impl EngineStd {
         &self,
         _client_num: u64,
         _args: &Args,
-        file: &mut std::fs::File,
+        file: &std::fs::File,
         offset: u64,
         buf: &mut [u8],
     ) {


### PR DESCRIPTION
There was a new Rust release => new beta as well.

Failures were:

    cs@devvm:[~/src/tokio-epoll-uring]: rustup run beta cargo clippy --workspace
    warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
    note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
    note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
        Checking tokio-epoll-uring v0.1.0 (/home/cs/src/tokio-epoll-uring/tokio-epoll-uring)
        Checking benchmark v0.1.0 (/home/cs/src/tokio-epoll-uring/benchmark)
    error: redundant redefinition of a binding
       --> benchmark/src/engines/tokio_spawn_blocking.rs:108:13
        |
    108 |         let buf = {
        |             ^^^
    ...
    143 |                         let buf = buf;
        |                         ^^^^^^^^^^^^^^
        |
        = help: remove the redefinition of `buf`
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_locals
        = note: `#[deny(clippy::redundant_locals)]` on by default

    warning: this argument is a mutable reference, but not used mutably
       --> benchmark/src/engines/std_thread.rs:110:15
        |
    110 |         file: &mut std::fs::File,
        |               ^^^^^^^^^^^^^^^^^^ help: consider changing to: `&std::fs::File`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
        = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default