### PR TITLE
enable depending on `tokio-epoll-uring` crate from macOS builds

### DIFF
--- a/tokio-epoll-uring/src/lib.rs
+++ b/tokio-epoll-uring/src/lib.rs
@@ -71,21 +71,25 @@ pub(crate) mod sealed {
 
 pub mod doc;
 
+#[cfg(target_os = "linux")]
 pub mod ops;
 
+#[cfg(target_os = "linux")]
 mod system;
 
-pub use system::lifecycle::handle::SystemHandle;
-pub use system::lifecycle::thread_local::{thread_local_system, Handle};
-pub use system::lifecycle::System;
-pub use system::submission::op_fut::Error as SystemError;
+#[cfg(target_os = "linux")]
+pub use {
+    crate::system::submission::op_fut::Error,
+    system::lifecycle::handle::SystemHandle,
+    system::lifecycle::thread_local::{thread_local_system, Handle},
+    system::lifecycle::System,
+    system::submission::op_fut::Error as SystemError,
+};
 
 pub use uring_common::buf::{BoundedBuf, BoundedBufMut, IoBuf, IoBufMut, Slice};
 pub use uring_common::io_fd::IoFd;
 
 pub(crate) mod util;
-
-pub use crate::system::submission::op_fut::Error;
 
 #[doc(hidden)]
 pub mod env_tunables {

--- a/uring-common/Cargo.toml
+++ b/uring-common/Cargo.toml
@@ -8,5 +8,5 @@ license = "MIT" # the same as tokio-uring at the time we forked it
 [dependencies]
 libc = "0.2.80"
 
-[target.'cfg(linux)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.6.0"

--- a/uring-common/Cargo.toml
+++ b/uring-common/Cargo.toml
@@ -7,4 +7,6 @@ license = "MIT" # the same as tokio-uring at the time we forked it
 
 [dependencies]
 libc = "0.2.80"
+
+[target.'cfg(linux)'.dependencies]
 io-uring = "0.6.0"

--- a/uring-common/src/lib.rs
+++ b/uring-common/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod buf;
 pub mod open_options;
+#[cfg(target_os = "linux")]
 pub mod open_options_io_uring_ext;
 
 pub mod io_fd;
 
+#[cfg(target_os = "linux")]
 pub use io_uring;

--- a/uring-common/src/open_options.rs
+++ b/uring-common/src/open_options.rs
@@ -39,7 +39,7 @@ pub struct OpenOptions {
     truncate: bool,
     create: bool,
     create_new: bool,
-    pub(crate) mode: libc::mode_t,
+    pub(crate) mode: u32,
     pub(crate) custom_flags: libc::c_int,
 }
 


### PR DESCRIPTION
Used by https://github.com/neondatabase/neon/pull/6355

The alternative would have been to require `tokio-epoll-uring` users to use `uring-common` in their `Cargo.toml`.

Instead, we keep the re-exports of `uring-common` from `tokio-epoll-uring`, so that users can think of it as one crate.
As a bonus, the examples look nice.