### PR TITLE
set MADV_DONTFORK on ring buffers & review+assert required io_uring features

### DIFF
--- a/tokio-epoll-uring/Cargo.toml
+++ b/tokio-epoll-uring/Cargo.toml
@@ -15,10 +15,10 @@ tokio = "1.29.1"
 tokio-util = "0.7.8"
 tracing = "0.1.37"
 uring-common = { path = "../uring-common" }
+nix = "0.26.2"
 
 [dev-dependencies]
 tempfile = "3.6.0"
 tracing-subscriber = "*"
-nix = "0.26.2"
 os_pipe = "1.1.4"
 assert-panic = "1.0.1"


### PR DESCRIPTION
I looked into `dontfork()` because of https://github.com/neondatabase/neon/issues/6373 ;

I don't think it matters for that particular issue, but, it's still unsafe to share the memory mappings with another process because the synchronization primitives that tokio-epoll-uring wraps around them wouldn't be shared across processes.

Also take the opporunity to review io_uring feature flags and make sure they're there or produce some papertrail explaining why we don't care.