### PR TITLE
fix: dropping an op future at yield_now() after it completed causes panic

### DIFF
--- a/tokio-epoll-uring/src/system/completion.rs
+++ b/tokio-epoll-uring/src/system/completion.rs
@@ -642,7 +642,9 @@ mod tests {
         let (read_task_jh, mut writer) = rt.block_on(async move {
             let (reader, writer) = os_pipe::pipe().unwrap();
             let jh = tokio::spawn(async move {
-                let system = System::launch_with_testing(Some(testing)).await.unwrap();
+                let system = System::launch_with_testing(Some(testing), None)
+                    .await
+                    .unwrap();
                 let reader =
                     unsafe { OwnedFd::from_raw_fd(nix::unistd::dup(reader.as_raw_fd()).unwrap()) };
                 let buf = vec![0; 1];

--- a/tokio-epoll-uring/src/system/test_util/shared_system_handle.rs
+++ b/tokio-epoll-uring/src/system/test_util/shared_system_handle.rs
@@ -28,7 +28,7 @@ impl SharedSystemHandle {
     pub(crate) async fn launch_with_testing(
         poller_testing: Option<PollerTesting>,
     ) -> Result<Self, LaunchResult> {
-        let handle = System::launch_with_testing(poller_testing).await?;
+        let handle = System::launch_with_testing(poller_testing, None).await?;
         Ok(Self(Arc::new(RwLock::new(Some(handle)))))
     }
 


### PR DESCRIPTION
Before this PR, dropping an operation future while it's in the `tokio::yield_now` would cause a panic.

This PR contains two commits: the first one reproduces the issue in a test.
The second one fixes the issue and repurposes the reproducer as a regression test.

Stacked atop https://github.com/neondatabase/tokio-epoll-uring/pull/38

fixes https://github.com/neondatabase/tokio-epoll-uring/issues/37