### PR TITLE
Use statx-sys instead of libc's statx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statx-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69c325f46f705b7a66fb87f0ebb999524a7363f30f05d373277b4ef7f409fe87"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1380,7 @@ dependencies = [
  "bytes",
  "io-uring 0.6.0",
  "libc",
+ "statx-sys",
 ]
 
 [[package]]

--- a/tokio-epoll-uring/src/ops/statx.rs
+++ b/tokio-epoll-uring/src/ops/statx.rs
@@ -2,7 +2,7 @@ use crate::system::submission::op_fut::Op;
 use crate::util::submitting_box::SubmittingBox;
 use std::{mem::MaybeUninit, os::fd::AsRawFd};
 use uring_common::libc;
-pub use uring_common::libc::statx;
+pub use uring_common::statx_sys::{self, statx};
 use uring_common::{
     io_fd::IoFd,
     io_uring::{self},
@@ -28,7 +28,7 @@ where
 {
     ByFileDescriptor {
         file: F,
-        statxbuf: Box<MaybeUninit<uring_common::libc::statx>>,
+        statxbuf: Box<MaybeUninit<statx>>,
     },
 }
 
@@ -40,7 +40,7 @@ where
 {
     ByFileDescriptor {
         file: F,
-        statxbuf: SubmittingBox<uring_common::libc::statx>,
+        statxbuf: SubmittingBox<statx>,
     },
 }
 
@@ -76,8 +76,8 @@ where
                     // https://github.com/tokio-rs/tokio-uring/blob/c4320fa2e7b146b28ad921ae25b552a0894c9697/src/io/statx.rs#L47-L61
                     statxbuf.start_submitting() as *mut uring_common::io_uring::types::statx,
                 )
-                .flags(libc::AT_EMPTY_PATH | libc::AT_STATX_SYNC_AS_STAT)
-                .mask(uring_common::libc::STATX_ALL)
+                .flags(libc::AT_EMPTY_PATH | statx_sys::AT_STATX_SYNC_AS_STAT)
+                .mask(uring_common::statx_sys::STATX_ALL)
                 .build()
             }
         }

--- a/tokio-epoll-uring/src/system/lifecycle/handle.rs
+++ b/tokio-epoll-uring/src/system/lifecycle/handle.rs
@@ -181,12 +181,12 @@ impl crate::SystemHandle {
     ) -> (
         F,
         Result<
-            Box<uring_common::libc::statx>,
+            Box<uring_common::statx_sys::statx>,
             crate::system::submission::op_fut::Error<std::io::Error>,
         >,
     ) {
         // TODO: avoid the allocation, or optimize using a slab cache?
-        let buf: Box<MaybeUninit<uring_common::libc::statx>> = Box::new(MaybeUninit::uninit());
+        let buf: Box<MaybeUninit<uring_common::statx_sys::statx>> = Box::new(MaybeUninit::uninit());
         let op = statx::op(statx::Resources::ByFileDescriptor {
             file,
             statxbuf: buf,
@@ -205,7 +205,7 @@ impl crate::SystemHandle {
                         // that the regular MaybeUninit::assume_init does. Out of precaution, do that here.
                         statxbuf.assume_init_ref();
                         let raw = Box::into_raw(statxbuf);
-                        Box::from_raw(raw as *mut uring_common::libc::statx)
+                        Box::from_raw(raw as *mut uring_common::statx_sys::statx)
                     }
                 }),
             ),

--- a/uring-common/Cargo.toml
+++ b/uring-common/Cargo.toml
@@ -11,3 +11,4 @@ bytes = { version = "1.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.6.0"
+statx-sys = "0.4.1"

--- a/uring-common/src/lib.rs
+++ b/uring-common/src/lib.rs
@@ -9,3 +9,5 @@ pub mod io_fd;
 pub use io_uring;
 #[cfg(target_os = "linux")]
 pub use libc;
+#[cfg(target_os = "linux")]
+pub use statx_sys;


### PR DESCRIPTION
This allows us to compile for musl, which we want for https://github.com/neondatabase/neon/issues/7889