### PR TITLE
Avoid overhead of constructing debug messages that are not printed

### DIFF
--- a/tokio-epoll-uring/src/system/slots.rs
+++ b/tokio-epoll-uring/src/system/slots.rs
@@ -253,9 +253,9 @@ impl<const O: usize> Slots<O> {
         // TODO: only do this if some env var is set?
         let (storage, unused_indices) = (&inner.storage, &inner.unused_indices);
         debug!(
-            "poller task got timeout: free slots = {} by state: {:?}",
+            "poller task got timeout: free slots = {} by state: {state:?}",
             unused_indices.len(),
-            {
+            state = {
                 // Note: This non-trivial piece of code is inside the debug! macro so that it
                 // doesn't get executed when tracing level is set to ignore debug events. If
                 // you want to move it out, use tracing::enabled to still avoid the overhead.

--- a/tokio-epoll-uring/src/system/slots.rs
+++ b/tokio-epoll-uring/src/system/slots.rs
@@ -252,28 +252,33 @@ impl<const O: usize> Slots<O> {
         let inner = self.inner.lock().unwrap();
         // TODO: only do this if some env var is set?
         let (storage, unused_indices) = (&inner.storage, &inner.unused_indices);
-        let mut by_state_discr = HashMap::new();
-        for s in storage {
-            match s {
-                Some(slot) => {
-                    let discr = slot.discriminant_str();
-                    by_state_discr
-                        .entry(discr)
-                        .and_modify(|v| *v += 1)
-                        .or_insert(1);
-                }
-                None => {
-                    by_state_discr
-                        .entry("None")
-                        .and_modify(|v| *v += 1)
-                        .or_insert(1);
-                }
-            }
-        }
         debug!(
             "poller task got timeout: free slots = {} by state: {:?}",
             unused_indices.len(),
-            by_state_discr
+            {
+                // Note: This non-trivial piece of code is inside the debug! macro so that it
+                // doesn't get executed when tracing level is set to ignore debug events. If
+                // you want to move it out, use tracing::enabled to still avoid the overhead.
+                let mut by_state_discr = HashMap::new();
+                for s in storage {
+                    match s {
+                        Some(slot) => {
+                            let discr = slot.discriminant_str();
+                            by_state_discr
+                                .entry(discr)
+                                .and_modify(|v| *v += 1)
+                                .or_insert(1);
+                        }
+                        None => {
+                            by_state_discr
+                                .entry("None")
+                                .and_modify(|v| *v += 1)
+                                .or_insert(1);
+                        }
+                    }
+                }
+                by_state_discr
+            }
         );
     }
 }


### PR DESCRIPTION
I noticed that the neon pageserver unit tests were taking much longer with tokio-epoll-uring than with std:fs. It was because many of the tests used tokio::time:pause(), and then did a call to tokio::time::timeout() with a long 1h timeout. With tokio-epoll-uring, the loop in poller_impl_impl() woke up 36000 times, i.e. once for every 100 ms of virtual time, before the timeout was reached. The significance of that varies greatly depend on debug vs release build; it's particularly bad when I use nightly compiler with cranelift codegen backend.

It would be better to avoid the wakeups every 100 ms altogether, if the debug-level events are not enabled, but it scares me to have such different behavior depending on a debug-level. It sounds like a recipe for very hard-to-debug bugs. Or perhaps the debug dumping could be just removed altogether? That would be good for saving battery life when the system is idle.