### PR TITLE
Add support for batch submission to the kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "763b2b82aee23fe46c14c792470080c26538396e9ea589f548298f26b22d7f41"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,9 +155,11 @@ checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 name = "benchmark"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "clap",
  "crossbeam-utils",
  "ctrlc",
+ "futures",
  "hdrhistogram",
  "humantime",
  "itertools",
@@ -1250,6 +1274,7 @@ name = "tokio-epoll-uring"
 version = "0.1.0"
 dependencies = [
  "assert-panic",
+ "async-stream",
  "bytes",
  "futures",
  "nix",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -6,8 +6,10 @@ description = "Benchmarks to compare tokio-epoll-uring performance to other solu
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+async-stream = "0.3.6"
 clap = { version = "4.3.9", features = ["help", "usage", "error-context", "derive"] }
 ctrlc = "3.4.0"
+futures = "0.3.28"
 libc = "0.2.147"
 rand = "0.8.5"
 timerfd = "1.5.0"

--- a/benchmark/src/engines/tokio_epoll_uring.rs
+++ b/benchmark/src/engines/tokio_epoll_uring.rs
@@ -1,3 +1,5 @@
+use futures::future::Either;
+use futures::StreamExt;
 use rand::Rng;
 use std::{
     alloc::Layout,
@@ -149,13 +151,17 @@ impl EngineTokioEpollUring {
             ClientWorkKind::NoWork {} => ClientWorkFd::NoWork,
         };
 
-        // alloc aligned to make O_DIRECT work
-        let buf = unsafe {
-            let ptr = std::alloc::alloc(Layout::from_size_align(block_size, block_size).unwrap());
-            assert!(!ptr.is_null());
-            Vec::from_raw_parts(ptr, 0, block_size)
-        };
-        let mut loop_buf = Some(buf);
+        // Allocate buffers to read into. Alignment is required to make O_DIRECT work.
+        let mut loop_bufs = Vec::with_capacity(args.batch_size);
+        for _ in 0..args.batch_size {
+            let buf = unsafe {
+                let ptr =
+                    std::alloc::alloc(Layout::from_size_align(block_size, block_size).unwrap());
+                assert!(!ptr.is_null());
+                Vec::from_raw_parts(ptr, 0, block_size)
+            };
+            loop_bufs.push(buf);
+        }
 
         let validate_buf = unsafe {
             let ptr = std::alloc::alloc(Layout::from_size_align(block_size, block_size).unwrap());
@@ -173,11 +179,15 @@ impl EngineTokioEpollUring {
             // simulate Timeline::layers.read().await
             let _guard = rwlock.read().await;
 
-            // find a random aligned 8k offset inside the file
+            // pick a random block-size-aligned offset inside the file for each IO in the batch
             debug_assert!(1024 * 1024 % block_size == 0);
-            let offset_in_file = rand::thread_rng()
-                .gen_range(0..=((args.file_size_mib.get() * 1024 * 1024 - 1) / block_size_u64))
-                * block_size_u64;
+            let mut offsets = Vec::with_capacity(args.batch_size);
+            for _ in 0..args.batch_size {
+                let offset_in_file = rand::thread_rng()
+                    .gen_range(0..=((args.file_size_mib.get() * 1024 * 1024 - 1) / block_size_u64))
+                    * block_size_u64;
+                offsets.push(offset_in_file);
+            }
 
             let start = std::time::Instant::now();
             match fd {
@@ -185,8 +195,6 @@ impl EngineTokioEpollUring {
                     raw_fd: file_fd,
                     validate,
                 } => {
-                    let owned_buf = loop_buf.take().unwrap();
-                    let file = unsafe { OwnedFd::from_raw_fd(file_fd) };
                     // We use it to get one io_uring submission & completion ring per core / executor thread.
                     // The thread-local rings are not great if there's block_in_place in the codebase. It's fine here.
                     // Ideally we'd have one submission ring per core and a single completion ring, because, completion
@@ -196,27 +204,65 @@ impl EngineTokioEpollUring {
 
                     let handle = tokio_epoll_uring::thread_local_system().await;
 
-                    let ((file, owned_buf), res) =
-                        handle.read(file, offset_in_file, owned_buf).await;
+                    let mut used_bufs = Vec::new();
+                    {
+                        // This stream submits the reads to io_uring and produces futures to wait
+                        // for their completion.
+                        let offsets_ref = &offsets;
+                        let loop_bufs_mut = &mut loop_bufs;
+                        let reads = async_stream::stream! {
+                            for &offset in offsets_ref.iter() {
+                                let file = unsafe { OwnedFd::from_raw_fd(file_fd) };
+                                let owned_buf = loop_bufs_mut.pop().unwrap();
+                                let handle = &handle;
 
-                    let count = res.unwrap();
-                    assert_eq!(count, owned_buf.len());
-                    assert_eq!(count, block_size);
+                                let read_fut = if args.batched {
+                                    Either::Left(
+                                        handle.read_batched(file, offset, owned_buf).await,
+                                    )
+                                } else {
+                                    Either::Right(handle.read(file, offset, owned_buf))
+                                };
+                                yield read_fut;
+                            }
+                            // All IOs have now been queued. Notify the kernel to start processing
+                            // them. (Some of them may already have been submitted implicitly, if
+                            // the batch size is larger than the ring size. This ensures that they
+                            // are all submitted.)
+                            if args.batched {
+                                handle.submit_batched().await.unwrap();
+                            }
+                        };
 
-                    if validate {
-                        let mut owned_validate_buf = loop_validate_buf.take().unwrap();
-                        owned_validate_buf.resize(block_size, 0);
-                        let std_file = unsafe { std::fs::File::from_raw_fd(file.as_raw_fd()) };
-                        let nread = std_file
-                            .read_at(&mut owned_validate_buf, offset_in_file)
-                            .unwrap();
-                        assert_eq!(nread, block_size);
-                        assert_eq!(owned_buf, owned_validate_buf);
-                        loop_validate_buf = Some(owned_validate_buf);
-                        let _ = std_file.into_raw_fd(); // we used as_raw_fd above, don't make the Drop of std_file close the fd
+                        // Process the results
+                        let reads = std::pin::pin!(reads);
+                        let mut reads = reads.buffered(args.batch_size + 1).enumerate();
+                        while let Some((idx, ((file, owned_buf), res))) = reads.next().await {
+                            let offset_in_file = offsets[idx];
+                            let count = res.unwrap();
+                            assert_eq!(count, owned_buf.len());
+                            assert_eq!(count, block_size);
+
+                            if validate {
+                                let mut owned_validate_buf = loop_validate_buf.take().unwrap();
+                                owned_validate_buf.resize(block_size, 0);
+                                let std_file =
+                                    unsafe { std::fs::File::from_raw_fd(file.as_raw_fd()) };
+                                let nread = std_file
+                                    .read_at(&mut owned_validate_buf, offset_in_file)
+                                    .unwrap();
+                                assert_eq!(nread, block_size);
+                                assert_eq!(owned_buf, owned_validate_buf);
+                                loop_validate_buf = Some(owned_validate_buf);
+                                let _ = std_file.into_raw_fd(); // we used as_raw_fd above, don't make the Drop of std_file close the fd
+                            }
+                            used_bufs.push(owned_buf);
+                            let _ = file.into_raw_fd(); // so that it's there for next iteration
+                        }
                     }
-                    loop_buf = Some(owned_buf);
-                    let _ = file.into_raw_fd(); // so that it's there for next iteration
+                    assert!(loop_bufs.is_empty());
+                    assert!(used_bufs.len() == args.batch_size);
+                    loop_bufs = used_bufs;
                 }
                 ClientWorkFd::TimerFd(_timerfd, _duration) => {
                     unimplemented!()

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -35,6 +35,10 @@ struct Args {
     num_clients: NonZeroU64,
     file_size_mib: NonZeroU64,
     block_size_shift: NonZeroU64,
+    #[clap(long, default_value = "1")]
+    batch_size: usize,
+    #[clap(long)]
+    batched: bool,
     #[clap(long, default_value = "until-ctrl-c")]
     run_duration: RunDuration,
     #[clap(subcommand)]

--- a/tokio-epoll-uring/Cargo.toml
+++ b/tokio-epoll-uring/Cargo.toml
@@ -18,6 +18,7 @@ uring-common = { path = "../uring-common" , features = [ "bytes" ] }
 nix = "0.26.2"
 
 [dev-dependencies]
+async-stream = "0.3.6"
 tempfile = "3.6.0"
 tracing-subscriber = "*"
 os_pipe = "1.1.4"

--- a/tokio-epoll-uring/src/system/completion.rs
+++ b/tokio-epoll-uring/src/system/completion.rs
@@ -645,7 +645,6 @@ mod tests {
             let jh = tokio::spawn(async move {
                 let system = System::launch_with_testing(
                     Some(testing),
-                    None,
                     &crate::metrics::GLOBAL_STORAGE,
                     Arc::new(()),
                 )

--- a/tokio-epoll-uring/src/system/completion.rs
+++ b/tokio-epoll-uring/src/system/completion.rs
@@ -276,7 +276,9 @@ async fn poller_impl(
         match &mut poller_guard.state {
             PollerState::ShuttingDownNoMorePreemptible => unreachable!(),
             PollerState::ShutDown => {
-                unreachable!("if poller_impl_impl shuts shuts down, we never get back here, caller guarantees it")
+                unreachable!(
+                    "if poller_impl_impl shuts down, we never get back here, caller guarantees it"
+                )
             }
             PollerState::ShuttingDownPreemptible(inner, req) => {
                 let new_state =

--- a/tokio-epoll-uring/src/system/lifecycle.rs
+++ b/tokio-epoll-uring/src/system/lifecycle.rs
@@ -22,8 +22,6 @@ use super::{
     submission::{SubmitSide, SubmitSideInner, SubmitSideNewArgs},
 };
 
-use slots::SlotsTesting;
-
 /// A running `tokio_epoll_uring` system. Use [`Self::launch`] to start, then [`SystemHandle`] to interact.
 pub struct System {
     #[allow(dead_code)]
@@ -109,18 +107,11 @@ impl System {
     where
         M: PerSystemMetrics,
     {
-        Self::launch_with_testing(
-            None,
-            None,
-            &crate::metrics::GLOBAL_STORAGE,
-            per_system_metrics,
-        )
-        .await
+        Self::launch_with_testing(None, &crate::metrics::GLOBAL_STORAGE, per_system_metrics).await
     }
 
     pub(crate) async fn launch_with_testing<M>(
         poller_testing: Option<PollerTesting>,
-        slots_testing: Option<SlotsTesting>,
         global_metrics_storage: &'static GlobalMetricsStorage,
         per_system_metrics: Arc<M>,
     ) -> Result<SystemHandle<M>, LaunchResult>
@@ -131,8 +122,7 @@ impl System {
 
         let (submit_side, poller_ready_fut) = {
             // TODO: should we mlock `slots`? io_uring mmap is mlocked, slots are equally important for the system to function;
-            let (slots_submit_side, slots_completion_side, slots_poller) =
-                super::slots::new(id, slots_testing.unwrap_or_default());
+            let (slots_submit_side, slots_completion_side, slots_poller) = super::slots::new(id);
 
             let uring = Box::new(
                 io_uring::IoUring::builder()

--- a/tokio-epoll-uring/src/system/lifecycle/handle.rs
+++ b/tokio-epoll-uring/src/system/lifecycle/handle.rs
@@ -9,7 +9,7 @@ use uring_common::{
 use crate::{
     metrics::PerSystemMetrics,
     ops::{fsync::FsyncOp, open_at::OpenAtOp, read::ReadOp, statx, write::WriteOp},
-    system::submission::{op_fut::execute_op, SubmitSide},
+    system::submission::{op_fut::enqueue_op, op_fut::execute_op, op_fut::SystemError, SubmitSide},
 };
 
 /// Owned handle to the [`System`](crate::System) created by [`System::launch`](crate::System::launch).
@@ -97,6 +97,8 @@ impl<M: PerSystemMetrics> crate::SystemHandle<M> {
             Arc::clone(&inner.per_system_metrics),
         )
     }
+
+    /// Read from a file at given offset. Similar to [std::os::unix::fs::FileExt::read_at].
     pub fn read<F: IoFd + Send, B: BoundedBufMut + Send>(
         &self,
         file: F,
@@ -116,6 +118,77 @@ impl<M: PerSystemMetrics> crate::SystemHandle<M> {
             Arc::clone(&inner.per_system_metrics),
         )
     }
+
+    /// This is like [Self::read], but we separate pushing the operation to the io_uring submission
+    /// queue, and notifying the kernel about it. This allows efficiently queuing multiple read
+    /// operations and submitting them all in one syscall.
+    ///
+    /// The first step - pushing to the submission queue - is done by this function. When the future
+    /// completes, the operation has been pushed to the submission queue. The second step is to
+    /// notify the kernel about the pending operation in the submission queue - see the
+    /// [Self::submit_batched] function. The final step is to wait for the IO to complete - that is
+    /// done by awaiting the future returned by this function.
+    ///
+    /// If the submission queue is full, any existing queued IOs are submitted and we wait for an IO
+    /// to complete and free up an IO slot.
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let system = tokio_epoll_uring::System::launch().await.unwrap();
+    /// # use std::sync::Arc;
+    ///
+    /// let file = std::fs::File::open("/dev/zero").unwrap();
+    /// let fd: Arc<std::os::fd::OwnedFd> = Arc::new(file.into());
+    ///
+    /// // Push two independent read IOs to the submission queue. These 'awaits' will complete
+    /// // immediately unless the submission queue is full.
+    /// let io1 = system.read_batched(fd.clone(), 0, vec![0; 512]).await;
+    /// let io2 = system.read_batched(fd.clone(), 1024, vec![0; 512]).await;
+    ///
+    /// // Notify the kernel to start processing the IOs that we enqueued
+    /// system.submit_batched().await;
+    ///
+    /// // Process results
+    /// let result1 = io1.await;
+    /// let result2 = io2.await;
+    ///
+    /// # }
+    /// ```
+    ///
+    /// Currently, this is the only function that supports batching, all the other functions submit
+    /// the operation immediately. It would be straightforward to split other functions into
+    /// separate enqueue and waits steps, too, but currently this is the only one where we have the
+    /// need.
+    ///
+    /// NOTE: If all the IO slots are in use, the submission does not complete until some pending IO
+    /// futures have completed (or dropped)! The above example relies on there being at least two
+    /// slots free. To ensure that in the general case, poll the completion futures concurrently
+    /// with submitting new IOs, for example by using a separate task or
+    /// [futures::stream::StreamExt::buffered].
+    pub async fn read_batched<F: IoFd + Send, B: BoundedBufMut + Send>(
+        &self,
+        file: F,
+        offset: u64,
+        buf: B,
+    ) -> impl std::future::Future<
+        Output = (
+            (F, B),
+            Result<usize, crate::system::submission::op_fut::Error<std::io::Error>>,
+        ),
+    > {
+        let op = ReadOp { file, offset, buf };
+        let inner = self.inner.as_ref().unwrap();
+        enqueue_op(
+            op,
+            inner.submit_side.weak(),
+            Arc::clone(&inner.per_system_metrics),
+        )
+        .await
+    }
+
     pub fn open<P: AsRef<Path>>(
         &self,
         path: P,
@@ -242,5 +315,18 @@ impl<M: PerSystemMetrics> crate::SystemHandle<M> {
             inner.submit_side.weak(),
             Arc::clone(&inner.per_system_metrics),
         )
+    }
+
+    /// Notify the kernel about enqueued operations in the submission queue. See
+    /// [Self::read_batched].
+    pub async fn submit_batched(&self) -> Result<(), SystemError> {
+        let inner = self.inner.as_ref().unwrap();
+        match inner.submit_side.weak().upgrade_to_open().await {
+            Some(mut open) => {
+                open.submit_raw();
+                Ok(())
+            }
+            None => Err(SystemError::SystemShuttingDown),
+        }
     }
 }

--- a/tokio-epoll-uring/src/system/slots.rs
+++ b/tokio-epoll-uring/src/system/slots.rs
@@ -4,7 +4,7 @@
 //!
 //! - Have a place to which we can transfer ownership of the resources (FD, buffer)
 //!   if the future gets dropped while op is still in flight.
-//! - Heep track of what ops are in flight so during system shutdown we know when we're done.
+//! - Keep track of what ops are in flight so during system shutdown we know when we're done.
 //! - Limit queue depth & provide means for a task to wait until it's the task's turn.
 //!   The queue depth limit is currently hard-coded to [`crate::system::RING_SIZE`].
 //!   The wait-until-it's-our-turn is implemented by the `tokio::sync::oneshot` returned by
@@ -25,9 +25,10 @@
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    future::poll_fn,
+    future::Future,
+    pin::Pin,
     sync::{Arc, Mutex, Weak},
-    task::Poll,
+    task::{Context, Poll},
 };
 
 use tokio::sync::oneshot;
@@ -69,30 +70,6 @@ struct SlotsInner {
     unused_indices: Vec<usize>,
     co_owner_live: [bool; co_owner::NUM_CO_OWNERS],
     state: SlotsInnerState,
-    #[cfg(test)]
-    testing: SlotsTesting,
-}
-
-#[cfg(test)]
-pub(crate) struct SlotsTesting {
-    pub(crate) test_on_wake: Box<
-        dyn Send
-            + Sync
-            + Fn() -> Option<tokio::sync::oneshot::Sender<tokio::sync::oneshot::Sender<()>>>,
-    >,
-}
-
-#[cfg(not(test))]
-#[derive(Default)]
-pub(crate) struct SlotsTesting;
-
-#[cfg(test)]
-impl Default for SlotsTesting {
-    fn default() -> Self {
-        Self {
-            test_on_wake: Box::new(|| None),
-        }
-    }
 }
 
 enum SlotsInnerState {
@@ -108,9 +85,6 @@ pub(crate) struct SlotHandle {
     // FIXME: why is this weak?
     slots_weak: SlotsWeak,
     idx: usize,
-    #[cfg(test)]
-    test_on_wake:
-        std::sync::Mutex<Option<tokio::sync::oneshot::Sender<tokio::sync::oneshot::Sender<()>>>>,
 }
 
 enum Slot {
@@ -128,7 +102,6 @@ enum Slot {
 
 pub(super) fn new(
     id: usize,
-    #[allow(unused_variables)] testing: SlotsTesting,
 ) -> (
     Slots<{ co_owner::SUBMIT_SIDE }>,
     Slots<{ co_owner::COMPLETION_SIDE }>,
@@ -150,8 +123,6 @@ pub(super) fn new(
                     inner_weak: inner_weak.clone(),
                 },
             },
-            #[cfg(test)]
-            testing,
         })
     });
     fn make_co_owner<const O: usize>(inner: &Arc<Mutex<SlotsInner>>) -> Slots<O> {
@@ -221,8 +192,6 @@ impl SlotsInner {
                     match waiter.send(SlotHandle {
                         slots_weak: myself.clone(),
                         idx,
-                        #[cfg(test)]
-                        test_on_wake: Mutex::new((self.testing.test_on_wake)()),
                     }) {
                         Ok(()) => {
                             trace!("handed `idx` to a waiter");
@@ -417,8 +386,6 @@ impl Slots<{ co_owner::SUBMIT_SIDE }> {
                         slot: SlotHandle {
                             slots_weak: myself.clone(),
                             idx,
-                            #[cfg(test)]
-                            test_on_wake: Mutex::new((inner.testing.test_on_wake)()),
                         },
                         queue_depth: num_in_use_slots,
                     },
@@ -437,11 +404,6 @@ impl Slots<{ co_owner::SUBMIT_SIDE }> {
     }
 }
 
-type UseForOpOutput<O> = (
-    <O as Op>::Resources,
-    Result<<O as Op>::Success, Error<<O as Op>::Error>>,
-);
-
 impl SlotHandle {
     /// Places 'op' in the given slot and submits the operation to io_uring. On success, returns a
     /// future to wait for its completion. Can fail if the system is being shut down.
@@ -449,9 +411,9 @@ impl SlotHandle {
         self,
         mut op: O,
         do_submit: S,
-    ) -> Result<impl std::future::Future<Output = UseForOpOutput<O>>, (O::Resources, SystemError)>
+    ) -> Result<WaitForCompletion<O>, (O::Resources, SystemError)>
     where
-        O: Op + Send + 'static,
+        O: Op + Send + 'static + Unpin,
         S: FnOnce(io_uring::squeue::Entry),
     {
         let sqe = op.make_sqe();
@@ -472,18 +434,117 @@ impl SlotHandle {
 
         do_submit(sqe);
 
-        Ok(self.wait_for_completion(op))
+        // The operation has been submitted. Construct the future to wait for its completion.
+        //
+        // NB: It's important not to bail out of here before constructing the WaitForCompletion
+        // future, because otherwise the 'op' and any resources it owns would get dropped, while the
+        // kernel would continue operate on the dropped resources! The most concerning case are
+        // memory buffers which would be use-after-freed by the kernel. For example, for a read
+        // uring op, the kernel could write into the buffer that has been freed and/or re-used.
+        Ok(WaitForCompletion::new(op, self))
     }
+}
 
-    async fn wait_for_completion<O: Op + Send + 'static>(
-        self,
-        op: O,
-    ) -> (O::Resources, Result<O::Success, Error<O::Error>>) {
-        let slot = self;
+pub struct WaitForCompletion<O>
+where
+    O: Op + Send + 'static + Unpin,
+{
+    // invariant: op.is_some() <=> we haven't observed the poll below complete yet
+    op: Option<O>,
+    slot: SlotHandle,
+    pub poll_count: usize,
+}
 
-        // invariant: op.is_some() <=> we haven't observed the poll_fn below complete yet
-        let op = std::sync::Mutex::new(Some(op));
+impl<O> WaitForCompletion<O>
+where
+    O: Op + Send + 'static + Unpin,
+{
+    fn new(op: O, slot: SlotHandle) -> Self {
+        WaitForCompletion {
+            op: Some(op),
+            slot,
+            poll_count: 0,
+        }
+    }
+}
 
+impl<O> Future for WaitForCompletion<O>
+where
+    O: Op + Send + 'static + Unpin,
+{
+    type Output = (O::Resources, Result<O::Success, Error<O::Error>>, usize);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        // Inspect the slot to check whether the poller task already processed the completion.
+        // If it has, good for us.
+        // If not, store a waker in the slot so the poller task will wake us up to poll again
+        // and observe the Slot::Ready then.
+        //
+        // If we get cancelled in the meantime (i.e., this future gets dropped), the drop method
+        // will make sure the resources stay alive until the op is complete.
+        this.poll_count += 1;
+        let try_upgrade_res = this.slot.slots_weak.try_upgrade_mut(|inner| {
+            let storage = &mut inner.storage;
+            let slot_storage_ref = &mut storage[this.slot.idx];
+            let slot_mut = slot_storage_ref.as_mut().unwrap();
+
+            match &mut *slot_mut {
+                Slot::Pending { waker } => {
+                    trace!("op is still pending, storing waker in it");
+                    let waker_mut_ref = waker.get_or_insert_with(|| cx.waker().clone());
+                    if !cx.waker().will_wake(waker_mut_ref) {
+                        waker.replace(cx.waker().clone());
+                    }
+                    Poll::Pending
+                }
+                Slot::PendingButFutureDropped { .. } => {
+                    unreachable!("if it's dropped, it's not pollable")
+                }
+                Slot::Ready { result: res } => {
+                    trace!("op is ready, returning resources to user");
+                    let res = *res;
+                    inner.return_slot(this.slot.idx);
+                    // SAFETY: the slot is ready, so, ownership is back with userspace.
+                    #[allow(unused_unsafe)]
+                    unsafe {
+                        let op = this.op.take().unwrap();
+                        let result = op.on_op_completion(res);
+                        Poll::Ready((result.0, result.1))
+                    }
+                }
+            }
+        });
+        match try_upgrade_res {
+            Err(()) => {
+                // SAFETY:
+                // This future has an outdated view of the system; it shut down in the meantime.
+                // Shutdown makes sure that all inflight ops complete, so,
+                // these resources are no longer owned by the kernel and can be returned as an error.
+                #[allow(unused_unsafe)]
+                unsafe {
+                    let op = this.op.take().unwrap();
+                    Poll::Ready((
+                        op.on_failed_submission(),
+                        Err(Error::System(SystemError::SystemShuttingDown)),
+                        this.poll_count,
+                    ))
+                }
+            }
+            Ok(Poll::Ready((resources, res))) => {
+                Poll::Ready((resources, res.map_err(Error::Op), this.poll_count))
+            }
+            Ok(Poll::Pending) => Poll::Pending,
+        }
+    }
+}
+
+impl<O> Drop for WaitForCompletion<O>
+where
+    O: Op + Send + 'static + Unpin,
+{
+    fn drop(&mut self) {
         // If this future gets dropped _before_ the op completes, we need to make sure
         // that the resources owned by the kernel continue to live until the op completes.
         // Otherwise, the kernel will operate on the dropped resource. The most concerning
@@ -492,143 +553,63 @@ impl SlotHandle {
         //
         // If this futures gets dropped _after_ the op completes but before this future
         // is poll()ed, we need to return the slot in addition to freeing the resources.
-        scopeguard::defer! {
-            if op.lock().unwrap().is_none() {
-                // fast-path to avoid the try_upgrade_mut() call
+        if self.op.is_none() {
+            // fast-path to avoid the try_upgrade_mut() call
+            return;
+        }
+        let res = self.slot.slots_weak.try_upgrade_mut(|inner| {
+            let Some(op) = self.op.take() else {
                 return;
-            }
-            let res = slot.slots_weak.try_upgrade_mut(|inner| {
-                let Some(op) = op.lock().unwrap().take() else {
-                    return;
-                };
-                let storage = &mut inner.storage;
-                let slot_storage_mut = &mut storage[slot.idx];
-                // the invariant is: `op.is_some() <=> `
-                let slot_mut = slot_storage_mut
-                    .as_mut()
-                    .expect("op is Some(), so the poll_fn below hasn't returned the slot yet");
-                match &mut *slot_mut {
-                    Slot::Pending { .. } => {
-                        // The resource needs to be kept alive until the op completes.
-                        // So, move it into the Slot.
-                        // `process_completion` will drop the box and return the slot
-                        // once it observes the completion.
-                        *slot_mut = Slot::PendingButFutureDropped {
-                            _resources_owned_by_kernel: Box::new(op),
-                        };
-                    }
-                    Slot::Ready { result } => {
-                        // The op completed and called the waker that would eventually cause this future to be polled
-                        // and transition from Inflight to one of the Done states. But this future got dropped first.
-                        // So, it's our job to drop the slot.
-                        *slot_mut = Slot::Ready { result: *result };
-                        inner.return_slot(slot.idx);
-                        // SAFETY:
-                        // The op is ready, hence the resources aren't onwed by the kernel anymore.
-                        #[allow(unused_unsafe)]
-                        unsafe {
-                            drop(op);
-                        }
-                    }
-                    Slot::PendingButFutureDropped { .. } => {
-                        unreachable!("above is the only transition into this state, and this function only runs once")
-                    }
+            };
+            let storage = &mut inner.storage;
+            let slot_storage_mut = &mut storage[self.slot.idx];
+            // the invariant is: `op.is_some() <=> `
+            let slot_mut = slot_storage_mut
+                .as_mut()
+                .expect("op is Some(), so the poll_fn below hasn't returned the slot yet");
+            match &mut *slot_mut {
+                Slot::Pending { .. } => {
+                    // The resource needs to be kept alive until the op completes.
+                    // So, move it into the Slot.
+                    // `process_completion` will drop the box and return the slot
+                    // once it observes the completion.
+                    *slot_mut = Slot::PendingButFutureDropped {
+                        _resources_owned_by_kernel: Box::new(op),
+                    };
                 }
-            });
-            match res {
-                Ok(()) => (),
-                Err(()) => {
+                Slot::Ready { result } => {
+                    // The op completed and called the waker that would eventually cause this future to be polled
+                    // and transition from Inflight to one of the Done states. But this future got dropped first.
+                    // So, it's our job to drop the slot.
+                    *slot_mut = Slot::Ready { result: *result };
+                    inner.return_slot(self.slot.idx);
                     // SAFETY:
-                    // This future has an outdated view of the system; it shut down in the meantime.
-                    // Shutdown makes sure that all inflight ops complete, so, it is safe to drop the resources owned by kernel at this point.
+                    // The op is ready, hence the resources aren't onwed by the kernel anymore.
                     #[allow(unused_unsafe)]
                     unsafe {
-                        let Some(op) = op.lock().unwrap().take() else {
-                            return;
-                        };
                         drop(op);
                     }
                 }
+                Slot::PendingButFutureDropped { .. } => {
+                    unreachable!("above is the only transition into this state, and this function only runs once")
+                }
             }
-        };
-
-        // Now that we've set up the scope guard, get to business.
-        // Inspect the slot to check whether the poller task already processed the completion.
-        // If it has, good for us.
-        // If not, store a waker in the slot so the poller task will wake us up to poll again
-        // and observe the Slot::Ready then.
-        //
-        // If we get cancelled in the meantime (i.e., this future gets dropped), the scopeguard
-        // will make sure the resources stay alive until the op is complete.
-        let mut poll_count = 0;
-        let poll_res = poll_fn(|cx| {
-            poll_count += 1;
-            let try_upgrade_res = slot.slots_weak.try_upgrade_mut(|inner| {
-                let storage = &mut inner.storage;
-                let slot_storage_ref = &mut storage[slot.idx];
-                let slot_mut = slot_storage_ref.as_mut().unwrap();
-
-                match &mut *slot_mut {
-                    Slot::Pending { waker } => {
-                        trace!("op is still pending, storing waker in it");
-                        let waker_mut_ref = waker.get_or_insert_with(|| cx.waker().clone());
-                        if !cx.waker().will_wake(waker_mut_ref) {
-                            waker.replace(cx.waker().clone());
-                        }
-                        Poll::Pending
-                    }
-                    Slot::PendingButFutureDropped { .. } => {
-                        unreachable!("if it's dropped, it's not pollable")
-                    }
-                    Slot::Ready { result: res } => {
-                        trace!("op is ready, returning resources to user");
-                        let res = *res;
-                        inner.return_slot(slot.idx);
-                        // SAFETY: the slot is ready, so, ownership is back with userspace.
-                        #[allow(unused_unsafe)]
-                        unsafe {
-                            let op = op.lock().unwrap().take().unwrap();
-                            Poll::Ready(op.on_op_completion(res))
-                        }
-                    }
+        });
+        match res {
+            Ok(()) => (),
+            Err(()) => {
+                // SAFETY:
+                // This future has an outdated view of the system; it shut down in the meantime.
+                // Shutdown makes sure that all inflight ops complete, so, it is safe to drop the resources owned by kernel at this point.
+                #[allow(unused_unsafe)]
+                unsafe {
+                    let Some(op) = self.op.take() else {
+                        return;
+                    };
+                    drop(op);
                 }
-            });
-            match try_upgrade_res {
-                Err(()) => {
-                    // SAFETY:
-                    // This future has an outdated view of the system; it shut down in the meantime.
-                    // Shutdown makes sure that all inflight ops complete, so,
-                    // these resources are no longer owned by the kernel and can be returned as an error.
-                    #[allow(unused_unsafe)]
-                    unsafe {
-                        let op = op.lock().unwrap().take().unwrap();
-                        Poll::Ready((
-                            op.on_failed_submission(),
-                            Err(Error::System(SystemError::SystemShuttingDown)),
-                        ))
-                    }
-                }
-                Ok(Poll::Ready((resources, res))) => {
-                    Poll::Ready((resources, res.map_err(Error::Op)))
-                }
-                Ok(Poll::Pending) => Poll::Pending,
-            }
-        })
-        .await;
-        assert!(poll_count >= 1);
-        #[cfg(test)]
-        {
-            let on_wake = { slot.test_on_wake.lock().unwrap().take() };
-            if let Some(on_wake) = on_wake {
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                on_wake.send(tx).unwrap();
-                rx.await.unwrap();
             }
         }
-        if poll_count == 1 && *crate::env_tunables::YIELD_TO_EXECUTOR_IF_READY_ON_FIRST_POLL {
-            tokio::task::yield_now().await;
-        }
-        poll_res
     }
 }
 
@@ -655,47 +636,5 @@ impl Slot {
             Slot::PendingButFutureDropped { .. } => "PendingButFutureDropped",
             Slot::Ready { .. } => "Ready",
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use crate::{system::slots::SlotsTesting, System};
-
-    // Regression-test for issue https://github.com/neondatabase/tokio-epoll-uring/issues/37
-    #[tokio::test]
-    async fn test_wait_for_completion_drop_behavior() {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let tx = Arc::new(Mutex::new(Some(tx)));
-        let system = System::launch_with_testing(
-            None,
-            Some(SlotsTesting {
-                test_on_wake: Box::new(move || {
-                    Some(
-                        tx.lock()
-                            .unwrap()
-                            .take()
-                            .expect("should only be called once, we only submit one nop here"),
-                    )
-                }),
-            }),
-            &crate::metrics::GLOBAL_STORAGE,
-            Arc::new(()),
-        )
-        .await
-        .unwrap();
-        let nop = tokio::spawn(system.nop());
-        let at_yield_point: tokio::sync::oneshot::Sender<()> = rx.await.unwrap();
-        nop.abort();
-        let Err(join_err) = nop.await else {
-            panic!("expecting join error after abort");
-        };
-        assert!(join_err.is_cancelled());
-        assert!(
-            at_yield_point.is_closed(),
-            "abort drops the nop op, and hence the oneshot receiver"
-        );
     }
 }

--- a/tokio-epoll-uring/src/system/slots.rs
+++ b/tokio-epoll-uring/src/system/slots.rs
@@ -443,11 +443,13 @@ type UseForOpOutput<O> = (
 );
 
 impl SlotHandle {
+    /// Places 'op' in the given slot and submits the operation to io_uring. On success, returns a
+    /// future to wait for its completion. Can fail if the system is being shut down.
     pub(crate) fn use_for_op<O, S>(
         self,
         mut op: O,
         do_submit: S,
-    ) -> impl std::future::Future<Output = UseForOpOutput<O>>
+    ) -> Result<impl std::future::Future<Output = UseForOpOutput<O>>, (O::Resources, SystemError)>
     where
         O: Op + Send + 'static,
         S: FnOnce(io_uring::squeue::Entry),
@@ -465,17 +467,12 @@ impl SlotHandle {
             }
         });
         let Ok(()) = res else {
-            return futures::future::Either::Left(async move {
-                (
-                    op.on_failed_submission(),
-                    Err(Error::<O::Error>::System(SystemError::SystemShuttingDown)),
-                )
-            });
+            return Err((op.on_failed_submission(), SystemError::SystemShuttingDown));
         };
 
         do_submit(sqe);
 
-        futures::future::Either::Right(self.wait_for_completion(op))
+        Ok(self.wait_for_completion(op))
     }
 
     async fn wait_for_completion<O: Op + Send + 'static>(

--- a/tokio-epoll-uring/src/system/submission.rs
+++ b/tokio-epoll-uring/src/system/submission.rs
@@ -87,20 +87,22 @@ impl Drop for SubmitSide {
 }
 
 impl SubmitSideOpen {
-    pub(crate) fn submit_raw(
+    pub(crate) fn push_raw(
         &mut self,
-        sqe: io_uring::squeue::Entry,
+        sqe: &io_uring::squeue::Entry,
     ) -> std::result::Result<(), SubmitError> {
-        self.sq.sync();
-        match unsafe { self.sq.push(&sqe) } {
+        match unsafe { self.sq.push(sqe) } {
             Ok(()) => {}
             Err(_queue_full) => {
                 return Err(SubmitError::QueueFull);
             }
         }
+        Ok(())
+    }
+
+    pub(crate) fn submit_raw(&mut self) {
         self.sq.sync();
         self.submitter.submit().unwrap();
-        Ok(())
     }
 }
 

--- a/tokio-epoll-uring/src/system/submission/op_fut.rs
+++ b/tokio-epoll-uring/src/system/submission/op_fut.rs
@@ -103,16 +103,18 @@ where
         }
     }
 
-    match open_guard.slots.try_get_slot() {
-        slots::TryGetSlotResult::Draining => (
-            op.on_failed_submission(),
-            Err(Error::System(SystemError::SystemShuttingDown)),
-        ),
+    let slot = match open_guard.slots.try_get_slot() {
+        slots::TryGetSlotResult::Draining => {
+            return (
+                op.on_failed_submission(),
+                Err(Error::System(SystemError::SystemShuttingDown)),
+            )
+        }
         slots::TryGetSlotResult::GotSlot { slot, queue_depth } => {
             per_system_metrics
                 .as_ref()
                 .observe_slots_submission_queue_depth(queue_depth);
-            slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)).await
+            slot
         }
         slots::TryGetSlotResult::NoSlots { later, queue_depth } => {
             // All slots are taken and we're waiting in line.
@@ -131,7 +133,7 @@ where
                     .unwrap()
                     .process_completions(ProcessCompletionsCause::Regular);
             }
-            let slot = match later.await {
+            match later.await {
                 Ok(slot) => slot,
                 Err(_dropped) => {
                     return (
@@ -139,8 +141,9 @@ where
                         Err(Error::System(SystemError::SystemShuttingDown)),
                     )
                 }
-            };
-            slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)).await
+            }
         }
-    }
+    };
+
+    slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)).await
 }

--- a/tokio-epoll-uring/src/system/submission/op_fut.rs
+++ b/tokio-epoll-uring/src/system/submission/op_fut.rs
@@ -145,5 +145,9 @@ where
         }
     };
 
-    slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)).await
+    match slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)) {
+        Ok(wait_fut) => wait_fut,
+        Err((resources, err)) => return (resources, Err(Error::System(err))),
+    }
+    .await
 }

--- a/tokio-epoll-uring/src/system/submission/op_fut.rs
+++ b/tokio-epoll-uring/src/system/submission/op_fut.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, sync::Arc};
+use std::{fmt::Display, future::Future, sync::Arc};
 
 /// An io_uring operation and the resources it operates on.
 ///
@@ -16,7 +16,7 @@ use uring_common::io_uring;
 
 use crate::{
     metrics::PerSystemMetrics,
-    system::{completion::ProcessCompletionsCause, slots},
+    system::{completion::ProcessCompletionsCause, slots, slots::WaitForCompletion},
 };
 
 use super::{SubmitSideOpenGuard, SubmitSideWeak};
@@ -48,6 +48,7 @@ impl<T: Display> Display for Error<T> {
     }
 }
 
+/// Push 'op' to the submission queue and submit it
 pub(crate) async fn execute_op<O, M>(
     op: O,
     submit_side: SubmitSideWeak,
@@ -57,57 +58,68 @@ where
     O: Op + Send + 'static + Unpin,
     M: PerSystemMetrics,
 {
-    let open_guard = match submit_side.upgrade_to_open().await {
+    // enqueue the operation and immediately wait for it
+    let wait_fut = enqueue_op_internal(op, submit_side, per_system_metrics, true).await;
+    wait_fut.await
+}
+
+/// Push 'op' to the submission queue
+pub(crate) async fn enqueue_op<O, M>(
+    op: O,
+    submit_side: SubmitSideWeak,
+    per_system_metrics: Arc<M>,
+) -> impl Future<Output = (O::Resources, Result<O::Success, Error<O::Error>>)>
+where
+    O: Op + Send + 'static + Unpin,
+    M: PerSystemMetrics,
+{
+    enqueue_op_internal(op, submit_side, per_system_metrics, false).await
+}
+
+/// Shared implementation of [execute_op] and [enqueue_op]
+pub(crate) async fn enqueue_op_internal<O, M>(
+    op: O,
+    submit_side: SubmitSideWeak,
+    per_system_metrics: Arc<M>,
+    submit_immediately: bool,
+) -> impl Future<Output = (O::Resources, Result<O::Success, Error<O::Error>>)>
+where
+    O: Op + Send + 'static + Unpin,
+    M: PerSystemMetrics,
+{
+    let mut open_guard = match submit_side.upgrade_to_open().await {
         Some(open) => open,
         None => {
-            return (
+            return wait_or_immediate_result(Err((
                 op.on_failed_submission(),
-                Err(Error::System(SystemError::SystemShuttingDown)),
-            );
+                Error::System(SystemError::SystemShuttingDown),
+            )));
         }
     };
 
-    fn do_submit(mut open_guard: SubmitSideOpenGuard, sqe: io_uring::squeue::Entry) {
-        if open_guard.submit_raw(sqe).is_err() {
-            // TODO: DESIGN: io_uring can deal have more ops inflight than the SQ.
-            // So, we could just submit_and_wait here. But, that'd prevent the
-            // current executor thread from making progress on other tasks.
-            //
-            // So, for now, keep SQ size == inflight ops size == Slots size.
-            // This potentially limits throughput if SQ size is chosen too small.
-            //
-            // FIXME: why not just async mutex?
-            unreachable!("the `ops` has same size as the SQ, so, if SQ is full, we wouldn't have been able to get this slot");
-        }
-
-        // this allows us to keep the possible guard in cq_guard because the arc lives on stack
-        #[allow(unused_assignments)]
-        let mut cq_owned = None;
-
-        let cq_guard = if *crate::env_tunables::PROCESS_COMPLETIONS_ON_SUBMIT {
-            let cq = Arc::clone(&open_guard.completion_side);
-            cq_owned = Some(cq);
-            Some(cq_owned.as_ref().expect("we just set it").lock().unwrap())
-        } else {
-            None
-        };
-        drop(open_guard); // drop it asap to enable timely shutdown
-
-        if let Some(mut cq) = cq_guard {
-            // opportunistically process completion immediately
-            // TODO do it during ::poll() as well?
-            //
-            // FIXME: why are we doing this while holding the SubmitSideOpen
-            cq.process_completions(ProcessCompletionsCause::Regular);
+    fn do_enqueue(open_guard: &mut SubmitSideOpenGuard, sqe: io_uring::squeue::Entry) {
+        if open_guard.push_raw(&sqe).is_err() {
+            open_guard.sq.sync();
+            if open_guard.push_raw(&sqe).is_err() {
+                // TODO: DESIGN: io_uring can deal have more ops inflight than the SQ.
+                // So, we could just submit_and_wait here. But, that'd prevent the
+                // current executor thread from making progress on other tasks.
+                //
+                // So, for now, keep SQ size == inflight ops size == Slots size.
+                // This potentially limits throughput if SQ size is chosen too small.
+                //
+                // FIXME: why not just async mutex?
+                unreachable!("the `ops` has same size as the SQ, so, if SQ is full, we wouldn't have been able to get this slot");
+            }
         }
     }
 
     let slot = match open_guard.slots.try_get_slot() {
         slots::TryGetSlotResult::Draining => {
-            return (
+            return wait_or_immediate_result(Err((
                 op.on_failed_submission(),
-                Err(Error::System(SystemError::SystemShuttingDown)),
-            )
+                Error::System(SystemError::SystemShuttingDown),
+            )))
         }
         slots::TryGetSlotResult::GotSlot { slot, queue_depth } => {
             per_system_metrics
@@ -117,6 +129,11 @@ where
         }
         slots::TryGetSlotResult::NoSlots { later, queue_depth } => {
             // All slots are taken and we're waiting in line.
+            //
+            // Nudge the kernel to start processing any IOs that we have already submitted, so that
+            // they will eventually complete and free up slots.
+            open_guard.submit_raw();
+
             // If enabled, do some opportunistic completion processing to wake up futures that will release ops slots.
             // This is in the hope that we'll wake ourselves up.
 
@@ -132,28 +149,72 @@ where
                     .unwrap()
                     .process_completions(ProcessCompletionsCause::Regular);
             }
+
             match later.await {
                 Ok(slot) => slot,
                 Err(_dropped) => {
-                    return (
+                    return wait_or_immediate_result(Err((
                         op.on_failed_submission(),
-                        Err(Error::System(SystemError::SystemShuttingDown)),
-                    )
+                        Error::System(SystemError::SystemShuttingDown),
+                    )))
                 }
             }
         }
     };
 
-    let (resources, result, poll_count) =
-        match slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)) {
-            Ok(wait_fut) => wait_fut,
-            Err((resources, err)) => return (resources, Err(Error::System(err))),
-        }
-        .await;
+    let wait_fut = match slot.use_for_op(op, |sqe| do_enqueue(&mut open_guard, sqe)) {
+        Ok(wait_fut) => wait_fut,
+        Err((op, err)) => return wait_or_immediate_result(Err((op, Error::System(err)))),
+    };
 
+    if submit_immediately {
+        open_guard.submit_raw();
+
+        // this allows us to keep the possible guard in cq_guard because the arc lives on stack
+        #[allow(unused_assignments)]
+        let mut cq_owned = None;
+
+        let cq_guard = if *crate::env_tunables::PROCESS_COMPLETIONS_ON_SUBMIT {
+            let cq = Arc::clone(&open_guard.completion_side);
+            cq_owned = Some(cq);
+            Some(cq_owned.as_ref().expect("we just set it").lock().unwrap())
+        } else {
+            None
+        };
+
+        // drop it to enable timely shutdown
+        drop(open_guard);
+
+        if let Some(mut cq) = cq_guard {
+            // opportunistically process completion immediately
+            // TODO do it during ::poll() as well?
+            //
+            // FIXME: why are we doing this while holding the SubmitSideOpen
+            cq.process_completions(ProcessCompletionsCause::Regular);
+        }
+    };
+
+    wait_or_immediate_result(Ok(wait_fut))
+}
+
+/// A helper that calls the future to wait for IO completion, or immediately returns a submission
+/// error.  This is needed to have a single future type for both, similar to
+/// [futures::future::Either].
+#[allow(clippy::type_complexity)]
+async fn wait_or_immediate_result<O>(
+    submit_result: Result<WaitForCompletion<O>, (O::Resources, Error<O::Error>)>,
+) -> (O::Resources, Result<O::Success, Error<O::Error>>)
+where
+    O: Op + Send + 'static + Unpin,
+{
+    let wait_fut = match submit_result {
+        Ok(wait_fut) => wait_fut,
+        Err((resources, err)) => return (resources, Err(err)),
+    };
+
+    let (resources, result, poll_count) = wait_fut.await;
     if poll_count == 1 && *crate::env_tunables::YIELD_TO_EXECUTOR_IF_READY_ON_FIRST_POLL {
         tokio::task::yield_now().await;
     }
-
     (resources, result)
 }

--- a/tokio-epoll-uring/src/system/submission/op_fut.rs
+++ b/tokio-epoll-uring/src/system/submission/op_fut.rs
@@ -54,7 +54,6 @@ pub(crate) async fn execute_op<O, M>(
     per_system_metrics: Arc<M>,
 ) -> (O::Resources, Result<O::Success, Error<O::Error>>)
 where
-    // FIXME: probably dont need the unpin
     O: Op + Send + 'static + Unpin,
     M: PerSystemMetrics,
 {
@@ -145,9 +144,16 @@ where
         }
     };
 
-    match slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)) {
-        Ok(wait_fut) => wait_fut,
-        Err((resources, err)) => return (resources, Err(Error::System(err))),
+    let (resources, result, poll_count) =
+        match slot.use_for_op(op, |sqe| do_submit(open_guard, sqe)) {
+            Ok(wait_fut) => wait_fut,
+            Err((resources, err)) => return (resources, Err(Error::System(err))),
+        }
+        .await;
+
+    if poll_count == 1 && *crate::env_tunables::YIELD_TO_EXECUTOR_IF_READY_ON_FIRST_POLL {
+        tokio::task::yield_now().await;
     }
-    .await
+
+    (resources, result)
 }

--- a/tokio-epoll-uring/src/system/test_util/shared_system_handle.rs
+++ b/tokio-epoll-uring/src/system/test_util/shared_system_handle.rs
@@ -68,4 +68,28 @@ impl SharedSystemHandle {
             .expect("SharedSystemHandle is shut down, cannot submit new operations");
         guard.read(file, offset, buf)
     }
+
+    pub async fn read_batched<B: IoBufMut + Send, F: crate::IoFd + Send>(
+        &self,
+        file: F,
+        offset: u64,
+        buf: B,
+    ) -> impl std::future::Future<Output = ((F, B), Result<usize, SystemError<std::io::Error>>)>
+    {
+        let guard = self.0.read().unwrap();
+        let guard = guard
+            .as_ref()
+            .expect("SharedSystemHandle is shut down, cannot submit new operations");
+        guard.read_batched(file, offset, buf).await
+    }
+
+    pub async fn submit_batched(
+        &self,
+    ) -> Result<(), crate::system::submission::op_fut::SystemError> {
+        let guard = self.0.read().unwrap();
+        let guard = guard
+            .as_ref()
+            .expect("SharedSystemHandle is shut down, cannot submit new operations");
+        guard.submit_batched().await
+    }
 }

--- a/tokio-epoll-uring/src/system/test_util/shared_system_handle.rs
+++ b/tokio-epoll-uring/src/system/test_util/shared_system_handle.rs
@@ -30,7 +30,6 @@ impl SharedSystemHandle {
     ) -> Result<Self, LaunchResult> {
         let handle = System::launch_with_testing(
             poller_testing,
-            None,
             &crate::metrics::GLOBAL_STORAGE,
             Arc::new(()),
         )

--- a/tokio-epoll-uring/src/system/tests.rs
+++ b/tokio-epoll-uring/src/system/tests.rs
@@ -82,7 +82,7 @@ async fn op_state_pending_but_future_dropped() {
 }
 
 #[tokio::test]
-async fn basic() {
+async fn read_from_pipe() {
     let system = SharedSystemHandle::launch().await.unwrap();
 
     let (reader, mut writer) = os_pipe::pipe().unwrap();
@@ -91,10 +91,69 @@ async fn basic() {
     writer.write_all(&[1]).unwrap();
 
     let buf = vec![0; 1];
+    // fixme: what does it mean to read from a pipe at an offset?
     let ((_, buf), res) = system.read(reader, 0, buf).await;
     let sz = res.unwrap();
     assert_eq!(sz, 1);
     assert_eq!(buf, vec![1]);
+
+    system.initiate_shutdown().await;
+}
+
+#[tokio::test]
+async fn read_batched() {
+    let system = SharedSystemHandle::launch().await.unwrap();
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let file_path = tempdir.path().join("some_file");
+
+    let mut content = Vec::new();
+    for _ in 0..1000 {
+        content.extend_from_slice(b"some content");
+    }
+    let mut std_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&file_path)
+        .unwrap();
+    std_file.write(&content).unwrap();
+    let fd = Arc::new(OwnedFd::from(std_file));
+
+    // Perform many read operations in a batched fashion.
+    let nreads = (RING_SIZE * 10) as usize;
+    let offsets: Vec<usize> = (0..nreads)
+        .map(|idx| (idx * 13) % (content.len() - 10))
+        .collect();
+    {
+        // This stream pushes the operations to the submission queue and yields futures to wait for
+        // their completions.
+        //
+        // Note: We must process the results concurrently with submitting new operations! Otherwise
+        // we will hang when all IO slots are filled up.
+        let system_ref = &system;
+        let offsets_ref = &offsets;
+        let submit_stream = async_stream::stream! {
+            for &offset in offsets_ref {
+                let wait_fut = system_ref.read_batched(fd.clone(), offset as u64, vec![0; 10]).await;
+                yield wait_fut;
+            }
+
+            // All submitted, wake up the kernel one last time
+            system_ref.submit_batched().await.unwrap();
+        };
+
+        // Start the IOs
+        let mut s = std::pin::pin!(submit_stream.buffered(offsets.len()));
+
+        // Process the results
+        for &offset in offsets_ref {
+            let ((_fd, buf), result) = s.next().await.unwrap();
+            assert_eq!(*result.as_ref().unwrap(), 10);
+            assert_eq!(buf, content[offset..(offset + 10)]);
+        }
+        assert!(s.next().await.is_none());
+    }
 
     system.initiate_shutdown().await;
 }

--- a/tokio-epoll-uring/src/system/tests.rs
+++ b/tokio-epoll-uring/src/system/tests.rs
@@ -208,12 +208,7 @@ fn test_metrics() {
     let metrics = Box::leak(Box::new(GlobalMetricsStorage::new_const()));
     let metrics_ptr = metrics as *mut _;
     let system = rt
-        .block_on(System::launch_with_testing(
-            None,
-            None,
-            metrics,
-            Arc::new(()),
-        ))
+        .block_on(System::launch_with_testing(None, metrics, Arc::new(())))
         .unwrap();
     assert_eq!(
         1,


### PR DESCRIPTION
I recommend reviewing the commits one by one, and using "Rebase and merge" to merge this PR. The last one introduces the new functions for batching, the previous ones are preliminary refactoring which I think make sense on their own too.

See the comment on the `read_batched` function and the new test case for how to use the new API. The idea is that you call `read_batched` multiple times, to submit all the IOs that you want to batch together, then call `submit_batched` to notify the kernel (i.e. perform the `io_uring_enter` call), and finally poll the futures for each IO to wait for their completion.

The new API is a bit tricky to use because submitting new IOs can block if the ring/slots is full (it's async, so "block" means that the future of submitting the IO might not immediately return Ready) . So you have to somehow ensure that it's not full before submitting new IOs, for which we haven't exposed any functions, or you have to poll the completion of previously submitted IOs concurrently with submitting new work, which is what the benchmark program does.

An alternative API would be to have one function to submit multiple IOs in one call, and fail if the ring is full. I don't think it changes the big picture much: you'd still need some logic to consume completions and retry, and I think all the refactorings here would still apply. If such an API would be easier to use for some callers, we could add that too, though. It would perhaps reduce the function call overhead of calling enqueue_op multiple times, but I don't think that makes a big difference.

This adds new options to the benchmark program, `--batch-size=N` and `--batched`. If you use `--batch-size` without `--batched`, the program submits multiple IOs with the existing `read` function, and then waits for them to complete. With `--batched`, it does the same but uses the new `read_batched` function. Usage example:

```
# using plain `read`
./target/release/benchmark --run-duration=5sec --batch-size=128 1 1 10 disk-access no-validate direct-io tokio-epoll-uring

# using new `read_batched` API
./target/release/benchmark --run-duration=5sec --batched --batch-size=128 1 1 10 disk-access no-validate direct-io tokio-epoll-uring
```

This is on top of PR #70.
